### PR TITLE
P1-1: Worker auth + security pack

### DIFF
--- a/apps/worker/src/auth/access.ts
+++ b/apps/worker/src/auth/access.ts
@@ -1,0 +1,75 @@
+import { base64UrlDecodeToBytes, base64UrlEncode, base64UrlDecodeToString } from '../lib/base64url';
+
+type AccessPayload = {
+  userId: string;
+  exp: number; // seconds since epoch
+};
+
+type AccessHeader = {
+  alg: 'HS256';
+  typ: 'JWT';
+};
+
+function utf8(input: string): Uint8Array {
+  return new TextEncoder().encode(input);
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', utf8(secret), { name: 'HMAC', hash: 'SHA-256' }, false, [
+    'sign',
+    'verify',
+  ]);
+}
+
+export async function mintAccessToken(userId: string, secret: string, expiresInSeconds: number): Promise<string> {
+  const header: AccessHeader = { alg: 'HS256', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  const payload: AccessPayload = { userId, exp };
+
+  const headerB64 = base64UrlEncode(utf8(JSON.stringify(header)));
+  const payloadB64 = base64UrlEncode(utf8(JSON.stringify(payload)));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const key = await importHmacKey(secret);
+  const sig = await crypto.subtle.sign('HMAC', key, utf8(signingInput));
+  const sigB64 = base64UrlEncode(sig);
+
+  return `${signingInput}.${sigB64}`;
+}
+
+export type VerifyAccessTokenResult =
+  | { ok: true; userId: string; exp: number }
+  | { ok: false; reason: 'missing' | 'invalid' | 'expired' };
+
+export async function verifyAccessToken(token: string | undefined, secret: string): Promise<VerifyAccessTokenResult> {
+  if (!token) return { ok: false, reason: 'missing' };
+  const parts = token.split('.');
+  if (parts.length !== 3) return { ok: false, reason: 'invalid' };
+
+  const [headerB64, payloadB64, sigB64] = parts;
+  if (!headerB64 || !payloadB64 || !sigB64) return { ok: false, reason: 'invalid' };
+
+  let header: AccessHeader;
+  let payload: AccessPayload;
+  try {
+    header = JSON.parse(base64UrlDecodeToString(headerB64)) as AccessHeader;
+    payload = JSON.parse(base64UrlDecodeToString(payloadB64)) as AccessPayload;
+  } catch {
+    return { ok: false, reason: 'invalid' };
+  }
+
+  if (header.alg !== 'HS256') return { ok: false, reason: 'invalid' };
+  if (!payload.userId || typeof payload.userId !== 'string') return { ok: false, reason: 'invalid' };
+  if (!payload.exp || typeof payload.exp !== 'number') return { ok: false, reason: 'invalid' };
+
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp <= now) return { ok: false, reason: 'expired' };
+
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const key = await importHmacKey(secret);
+  const sigBytes = base64UrlDecodeToBytes(sigB64);
+  const ok = await crypto.subtle.verify('HMAC', key, sigBytes, utf8(signingInput));
+  if (!ok) return { ok: false, reason: 'invalid' };
+
+  return { ok: true, userId: payload.userId, exp: payload.exp };
+}

--- a/apps/worker/src/auth/cookies.ts
+++ b/apps/worker/src/auth/cookies.ts
@@ -1,0 +1,48 @@
+import { serializeCookie } from '../lib/cookies';
+
+export const ACCESS_COOKIE = '__Host-ve_access';
+export const REFRESH_COOKIE = '__Host-ve_refresh';
+
+export type CookieSecurity = {
+  secure: boolean;
+};
+
+export function accessCookie(value: string, maxAgeSeconds: number, sec: CookieSecurity): string {
+  return serializeCookie(ACCESS_COOKIE, value, {
+    path: '/',
+    httpOnly: true,
+    secure: sec.secure,
+    sameSite: 'Lax',
+    maxAge: maxAgeSeconds,
+  });
+}
+
+export function refreshCookie(value: string, maxAgeSeconds: number, sec: CookieSecurity): string {
+  return serializeCookie(REFRESH_COOKIE, value, {
+    path: '/',
+    httpOnly: true,
+    secure: sec.secure,
+    sameSite: 'Lax',
+    maxAge: maxAgeSeconds,
+  });
+}
+
+export function clearAccessCookie(sec: CookieSecurity): string {
+  return serializeCookie(ACCESS_COOKIE, '', {
+    path: '/',
+    httpOnly: true,
+    secure: sec.secure,
+    sameSite: 'Lax',
+    maxAge: 0,
+  });
+}
+
+export function clearRefreshCookie(sec: CookieSecurity): string {
+  return serializeCookie(REFRESH_COOKIE, '', {
+    path: '/',
+    httpOnly: true,
+    secure: sec.secure,
+    sameSite: 'Lax',
+    maxAge: 0,
+  });
+}

--- a/apps/worker/src/auth/googleIdToken.ts
+++ b/apps/worker/src/auth/googleIdToken.ts
@@ -1,0 +1,106 @@
+import { base64UrlDecodeToBytes, base64UrlDecodeToString } from '../lib/base64url';
+
+export type GoogleIdTokenClaims = {
+  iss: string;
+  aud: string;
+  sub: string;
+  exp: number;
+};
+
+type JwtHeader = {
+  alg: string;
+  kid?: string;
+  typ?: string;
+};
+
+type Jwks = {
+  keys: Array<Record<string, unknown>>;
+};
+
+function utf8(input: string): Uint8Array {
+  return new TextEncoder().encode(input);
+}
+
+async function importRs256PublicKey(jwk: JsonWebKey): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify'],
+  );
+}
+
+function isAllowedIssuer(iss: string): boolean {
+  return iss === 'https://accounts.google.com' || iss === 'accounts.google.com';
+}
+
+export type VerifyGoogleIdTokenDeps = {
+  fetchJwks: (url: string) => Promise<Jwks>;
+  nowSeconds?: () => number;
+};
+
+let cachedJwks: { url: string; fetchedAtMs: number; jwks: Jwks } | null = null;
+
+async function getJwks(url: string, deps: VerifyGoogleIdTokenDeps): Promise<Jwks> {
+  const nowMs = Date.now();
+  if (cachedJwks && cachedJwks.url === url && nowMs - cachedJwks.fetchedAtMs < 10 * 60 * 1000) {
+    return cachedJwks.jwks;
+  }
+  const jwks = await deps.fetchJwks(url);
+  cachedJwks = { url, fetchedAtMs: nowMs, jwks };
+  return jwks;
+}
+
+export type VerifyGoogleIdTokenResult =
+  | { ok: true; userId: string; claims: GoogleIdTokenClaims }
+  | { ok: false; reason: 'invalid' | 'expired' | 'bad_audience' };
+
+export async function verifyGoogleIdToken(
+  idToken: string,
+  googleClientIds: string[],
+  jwksUrl: string,
+  deps: VerifyGoogleIdTokenDeps,
+): Promise<VerifyGoogleIdTokenResult> {
+  const parts = idToken.split('.');
+  if (parts.length !== 3) return { ok: false, reason: 'invalid' };
+  const [h, p, s] = parts;
+  if (!h || !p || !s) return { ok: false, reason: 'invalid' };
+
+  let header: JwtHeader;
+  let claims: GoogleIdTokenClaims;
+  try {
+    header = JSON.parse(base64UrlDecodeToString(h)) as JwtHeader;
+    claims = JSON.parse(base64UrlDecodeToString(p)) as GoogleIdTokenClaims;
+  } catch {
+    return { ok: false, reason: 'invalid' };
+  }
+
+  if (header.alg !== 'RS256') return { ok: false, reason: 'invalid' };
+  if (!claims.sub || !claims.exp || !claims.iss || !claims.aud) return { ok: false, reason: 'invalid' };
+  if (!isAllowedIssuer(claims.iss)) return { ok: false, reason: 'invalid' };
+
+  if (!googleClientIds.includes(claims.aud)) return { ok: false, reason: 'bad_audience' };
+
+  const now = deps.nowSeconds?.() ?? Math.floor(Date.now() / 1000);
+  if (claims.exp <= now) return { ok: false, reason: 'expired' };
+
+  const jwks = await getJwks(jwksUrl, deps);
+  const kid = header.kid;
+  const keyRecord = jwks.keys.find((k) => (kid ? k.kid === kid : true));
+  if (!keyRecord) return { ok: false, reason: 'invalid' };
+
+  const jwk = keyRecord as unknown as JsonWebKey;
+  const key = await importRs256PublicKey(jwk);
+
+  const signingInput = utf8(`${h}.${p}`);
+  const signature = base64UrlDecodeToBytes(s);
+  const ok = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', key, signature, signingInput);
+  if (!ok) return { ok: false, reason: 'invalid' };
+
+  return { ok: true, userId: claims.sub, claims };
+}
+
+export function clearJwksCacheForTests(): void {
+  cachedJwks = null;
+}

--- a/apps/worker/src/auth/jwksFetch.ts
+++ b/apps/worker/src/auth/jwksFetch.ts
@@ -1,0 +1,7 @@
+export type Jwks = { keys: Array<Record<string, unknown>> };
+
+export async function fetchJwks(url: string): Promise<Jwks> {
+  const res = await fetch(url, { cf: { cacheTtl: 600, cacheEverything: true } as never });
+  if (!res.ok) throw new Error(`jwks_fetch_failed:${res.status}`);
+  return (await res.json()) as Jwks;
+}

--- a/apps/worker/src/auth/refresh.ts
+++ b/apps/worker/src/auth/refresh.ts
@@ -1,0 +1,34 @@
+import { base64UrlEncode } from '../lib/base64url';
+
+export type RefreshSession = {
+  userId: string;
+  createdAt: string;
+};
+
+export type RefreshStore = {
+  get(token: string): Promise<RefreshSession | null>;
+  put(token: string, session: RefreshSession, ttlSeconds: number): Promise<void>;
+  del(token: string): Promise<void>;
+};
+
+export function kvRefreshStore(kv: KVNamespace): RefreshStore {
+  return {
+    async get(token) {
+      const raw = await kv.get(`refresh:${token}`);
+      if (!raw) return null;
+      return JSON.parse(raw) as RefreshSession;
+    },
+    async put(token, session, ttlSeconds) {
+      await kv.put(`refresh:${token}`, JSON.stringify(session), { expirationTtl: ttlSeconds });
+    },
+    async del(token) {
+      await kv.delete(`refresh:${token}`);
+    },
+  };
+}
+
+export function mintRefreshToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}

--- a/apps/worker/src/auth/session.test.ts
+++ b/apps/worker/src/auth/session.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import worker from '../index';
+import { ACCESS_COOKIE, REFRESH_COOKIE } from './cookies';
+import { base64UrlEncode } from '../lib/base64url';
+import { clearJwksCacheForTests } from './googleIdToken';
+
+class MemoryKV {
+  private store = new Map<string, { value: string; expiresAtMs?: number }>();
+
+  async get(key: string, type?: 'text' | 'json' | 'arrayBuffer' | 'stream'): Promise<any> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAtMs !== undefined && Date.now() > entry.expiresAtMs) {
+      this.store.delete(key);
+      return null;
+    }
+
+    if (!type || type === 'text') return entry.value;
+    if (type === 'json') return JSON.parse(entry.value);
+    if (type === 'arrayBuffer') return new TextEncoder().encode(entry.value).buffer;
+    if (type === 'stream') return new Response(entry.value).body;
+    return entry.value;
+  }
+
+  async put(key: string, value: string, options?: any): Promise<void> {
+    const ttlSeconds = options?.expirationTtl;
+    const expiresAtMs = ttlSeconds ? Date.now() + ttlSeconds * 1000 : undefined;
+    this.store.set(key, { value, expiresAtMs });
+  }
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+}
+
+async function mintTestGoogleIdToken(args: {
+  aud: string;
+  sub: string;
+  iss?: string;
+  expSecondsFromNow?: number;
+}) {
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+
+  const publicJwk = (await crypto.subtle.exportKey('jwk', keyPair.publicKey)) as JsonWebKey & {
+    kid?: string;
+    alg?: string;
+    use?: string;
+  };
+  publicJwk.kid = 'test-kid';
+  publicJwk.alg = 'RS256';
+  publicJwk.use = 'sig';
+
+  const header = { alg: 'RS256', kid: 'test-kid', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + (args.expSecondsFromNow ?? 60);
+  const payload = {
+    iss: args.iss ?? 'https://accounts.google.com',
+    aud: args.aud,
+    sub: args.sub,
+    exp,
+  };
+
+  const enc = (obj: unknown) => base64UrlEncode(new TextEncoder().encode(JSON.stringify(obj)));
+
+  const signingInput = `${enc(header)}.${enc(payload)}`;
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    keyPair.privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+  const sigB64 = base64UrlEncode(signature);
+
+  return {
+    token: `${signingInput}.${sigB64}`,
+    jwks: { keys: [publicJwk] },
+  };
+}
+
+function extractSetCookies(res: Response): string[] {
+  const anyHeaders = res.headers as unknown as { getSetCookie?: () => string[] };
+  if (typeof anyHeaders.getSetCookie === 'function') return anyHeaders.getSetCookie();
+
+  const single = res.headers.get('set-cookie');
+  if (!single) return [];
+
+  // Our worker cookies do not set Expires=, so splitting on commas is safe.
+  // Prefer splitting on cookie-name boundary to avoid accidental splits.
+  return single
+    .split(/,(?=__Host-ve_)/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+describe('session/auth flow', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    clearJwksCacheForTests();
+  });
+
+  it('login sets cookies and /api/me returns userId', async () => {
+    const { token, jwks } = await mintTestGoogleIdToken({ aud: 'client-1', sub: 'u_123' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch' as never).mockImplementation(async () => {
+      return new Response(JSON.stringify(jwks), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+
+    const env = {
+      KV: new MemoryKV(),
+      R2: {} as unknown as R2Bucket,
+      APP_ORIGINS: 'http://localhost:5173',
+      GOOGLE_CLIENT_IDS: 'client-1',
+      SESSION_HMAC_SECRET: 'test-secret',
+      GOOGLE_JWKS_URL: 'https://jwks.example.test',
+      ACCESS_TTL_SECONDS: '3600',
+      REFRESH_TTL_SECONDS: '86400',
+    };
+
+    const gCsrf = 'csrf-1';
+
+    const loginRes = await worker.fetch(
+      new Request('http://worker.test/api/session', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          'Content-Type': 'application/json',
+          Cookie: `g_csrf_token=${gCsrf}`,
+        },
+        body: JSON.stringify({ credential: token, g_csrf_token: gCsrf }),
+      }),
+      env as never,
+    );
+
+    expect(loginRes.status).toBe(204);
+    expect(fetchSpy).toHaveBeenCalled();
+
+    const setCookies = extractSetCookies(loginRes);
+    expect(setCookies.length).toBeGreaterThanOrEqual(2);
+
+    const access = setCookies.find((c) => c.startsWith(`${ACCESS_COOKIE}=`));
+    const refresh = setCookies.find((c) => c.startsWith(`${REFRESH_COOKIE}=`));
+    expect(access).toBeTruthy();
+    expect(refresh).toBeTruthy();
+
+    const cookieHeader = [access!, refresh!]
+      .map((c) => c.split(';')[0])
+      .join('; ');
+
+    const meRes = await worker.fetch(
+      new Request('http://worker.test/api/me', {
+        method: 'GET',
+        headers: { Cookie: cookieHeader },
+      }),
+      env as never,
+    );
+
+    expect(meRes.status).toBe(200);
+    const json = await meRes.json();
+    expect(json).toEqual({ userId: 'u_123' });
+  });
+
+  it('refresh rotates refresh token and invalidates the old one', async () => {
+    const { token, jwks } = await mintTestGoogleIdToken({ aud: 'client-1', sub: 'u_456' });
+
+    vi.spyOn(globalThis, 'fetch' as never).mockImplementation(async () => {
+      return new Response(JSON.stringify(jwks), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+
+    const env = {
+      KV: new MemoryKV(),
+      R2: {} as unknown as R2Bucket,
+      APP_ORIGINS: 'http://localhost:5173',
+      GOOGLE_CLIENT_IDS: 'client-1',
+      SESSION_HMAC_SECRET: 'test-secret',
+      GOOGLE_JWKS_URL: 'https://jwks.example.test',
+      ACCESS_TTL_SECONDS: '3600',
+      REFRESH_TTL_SECONDS: '86400',
+    };
+
+    const gCsrf = 'csrf-2';
+
+    const loginRes = await worker.fetch(
+      new Request('http://worker.test/api/session', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          'Content-Type': 'application/json',
+          Cookie: `g_csrf_token=${gCsrf}`,
+        },
+        body: JSON.stringify({ credential: token, g_csrf_token: gCsrf }),
+      }),
+      env as never,
+    );
+
+    expect(loginRes.status).toBe(204);
+
+    const setCookies1 = extractSetCookies(loginRes);
+    const refresh1 = setCookies1.find((c) => c.startsWith(`${REFRESH_COOKIE}=`))!;
+
+    const refreshRes = await worker.fetch(
+      new Request('http://worker.test/api/session/refresh', {
+        method: 'POST',
+        headers: { Origin: 'http://localhost:5173', Cookie: refresh1.split(';')[0] },
+      }),
+      env as never,
+    );
+
+    expect(refreshRes.status).toBe(204);
+    const setCookies2 = extractSetCookies(refreshRes);
+    const refresh2 = setCookies2.find((c) => c.startsWith(`${REFRESH_COOKIE}=`))!;
+    expect(refresh2).not.toEqual(refresh1);
+
+    const oldRefreshTry = await worker.fetch(
+      new Request('http://worker.test/api/session/refresh', {
+        method: 'POST',
+        headers: { Origin: 'http://localhost:5173', Cookie: refresh1.split(';')[0] },
+      }),
+      env as never,
+    );
+
+    expect(oldRefreshTry.status).toBe(401);
+  });
+
+  it('rejects bad Origin for state-changing endpoints', async () => {
+    const env = {
+      KV: new MemoryKV(),
+      R2: {} as unknown as R2Bucket,
+      APP_ORIGINS: 'http://localhost:5173',
+      GOOGLE_CLIENT_IDS: 'client-1',
+      SESSION_HMAC_SECRET: 'test-secret',
+    };
+
+    const res = await worker.fetch(
+      new Request('http://worker.test/api/session/refresh', {
+        method: 'POST',
+        headers: { Origin: 'http://evil.test' },
+      }),
+      env as never,
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('forbidden');
+  });
+
+  it('requires matching g_csrf_token cookie + body token on login', async () => {
+    const { token, jwks } = await mintTestGoogleIdToken({ aud: 'client-1', sub: 'u_789' });
+
+    vi.spyOn(globalThis, 'fetch' as never).mockImplementation(async () => {
+      return new Response(JSON.stringify(jwks), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+
+    const env = {
+      KV: new MemoryKV(),
+      R2: {} as unknown as R2Bucket,
+      APP_ORIGINS: 'http://localhost:5173',
+      GOOGLE_CLIENT_IDS: 'client-1',
+      SESSION_HMAC_SECRET: 'test-secret',
+      GOOGLE_JWKS_URL: 'https://jwks.example.test',
+    };
+
+    const res = await worker.fetch(
+      new Request('http://worker.test/api/session', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          'Content-Type': 'application/json',
+          Cookie: 'g_csrf_token=csrf-a',
+        },
+        body: JSON.stringify({ credential: token, g_csrf_token: 'csrf-b' }),
+      }),
+      env as never,
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('bad_csrf');
+  });
+});

--- a/apps/worker/src/auth/session.ts
+++ b/apps/worker/src/auth/session.ts
@@ -1,0 +1,103 @@
+import { resolveEnv, type Env } from '../env';
+import { parseCookieHeader } from '../lib/cookies';
+import { json, noContent, unauthorized } from '../lib/http';
+import { mintAccessToken, verifyAccessToken } from './access';
+import { clearAccessCookie, clearRefreshCookie, accessCookie, refreshCookie, REFRESH_COOKIE, ACCESS_COOKIE } from './cookies';
+import { kvRefreshStore, mintRefreshToken } from './refresh';
+import { verifyGoogleIdToken } from './googleIdToken';
+import { fetchJwks } from './jwksFetch';
+import { verifyGoogleCsrfToken } from '../security/csrf';
+
+export type SessionHandlers = {
+  login: (request: Request, env: Env) => Promise<Response>;
+  refresh: (request: Request, env: Env) => Promise<Response>;
+  logout: (request: Request, env: Env) => Promise<Response>;
+  me: (request: Request, env: Env) => Promise<Response>;
+};
+
+function isSecureRequest(request: Request): boolean {
+  const url = new URL(request.url);
+  return url.protocol === 'https:';
+}
+
+export const sessionHandlers: SessionHandlers = {
+  async login(request, env) {
+    const resolved = resolveEnv(env);
+
+    const body = (await request.json().catch(() => null)) as null | { credential?: string; g_csrf_token?: string };
+    if (!body?.credential) return json(400, { error: 'bad_request' });
+
+    if (!verifyGoogleCsrfToken(request, body.g_csrf_token)) return json(400, { error: 'bad_csrf' });
+
+    const verify = await verifyGoogleIdToken(body.credential, resolved.googleClientIds, resolved.googleJwksUrl, {
+      fetchJwks,
+    });
+
+    if (!verify.ok) return unauthorized();
+
+    const store = kvRefreshStore(env.KV);
+    const refreshToken = mintRefreshToken();
+    await store.put(refreshToken, { userId: verify.userId, createdAt: new Date().toISOString() }, resolved.refreshTtlSeconds);
+
+    const access = await mintAccessToken(verify.userId, resolved.sessionHmacSecret, resolved.accessTtlSeconds);
+
+    const sec = { secure: isSecureRequest(request) };
+    const headers = new Headers();
+    headers.append('Set-Cookie', accessCookie(access, resolved.accessTtlSeconds, sec));
+    headers.append('Set-Cookie', refreshCookie(refreshToken, resolved.refreshTtlSeconds, sec));
+
+    return noContent({ headers });
+  },
+
+  async refresh(request, env) {
+    const resolved = resolveEnv(env);
+
+    const cookies = parseCookieHeader(request.headers.get('Cookie'));
+    const token = cookies[REFRESH_COOKIE];
+    if (!token) return unauthorized();
+
+    const store = kvRefreshStore(env.KV);
+    const session = await store.get(token);
+    if (!session) return unauthorized();
+
+    await store.del(token);
+    const nextRefresh = mintRefreshToken();
+    await store.put(nextRefresh, { userId: session.userId, createdAt: new Date().toISOString() }, resolved.refreshTtlSeconds);
+
+    const access = await mintAccessToken(session.userId, resolved.sessionHmacSecret, resolved.accessTtlSeconds);
+
+    const sec = { secure: isSecureRequest(request) };
+    const headers = new Headers();
+    headers.append('Set-Cookie', accessCookie(access, resolved.accessTtlSeconds, sec));
+    headers.append('Set-Cookie', refreshCookie(nextRefresh, resolved.refreshTtlSeconds, sec));
+
+    return noContent({ headers });
+  },
+
+  async logout(request, env) {
+    const resolved = resolveEnv(env);
+
+    const cookies = parseCookieHeader(request.headers.get('Cookie'));
+    const token = cookies[REFRESH_COOKIE];
+    const store = kvRefreshStore(env.KV);
+    if (token) await store.del(token);
+
+    const sec = { secure: isSecureRequest(request) };
+    const headers = new Headers();
+    headers.append('Set-Cookie', clearAccessCookie(sec));
+    headers.append('Set-Cookie', clearRefreshCookie(sec));
+
+    return noContent({ headers });
+  },
+
+  async me(request, env) {
+    const resolved = resolveEnv(env);
+
+    const cookies = parseCookieHeader(request.headers.get('Cookie'));
+    const token = cookies[ACCESS_COOKIE];
+    const verified = await verifyAccessToken(token, resolved.sessionHmacSecret);
+    if (!verified.ok) return unauthorized();
+
+    return json(200, { userId: verified.userId });
+  },
+};

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -1,0 +1,47 @@
+export type Env = {
+  KV: KVNamespace;
+  R2: R2Bucket;
+  APP_ORIGINS?: string; // comma-separated
+  GOOGLE_CLIENT_IDS?: string; // comma-separated
+  GOOGLE_JWKS_URL?: string;
+  SESSION_HMAC_SECRET?: string;
+  ACCESS_TTL_SECONDS?: string;
+  REFRESH_TTL_SECONDS?: string;
+};
+
+export type ResolvedEnv = {
+  allowedOrigins: string[];
+  googleClientIds: string[];
+  googleJwksUrl: string;
+  sessionHmacSecret: string;
+  accessTtlSeconds: number;
+  refreshTtlSeconds: number;
+};
+
+export function resolveEnv(env: Env): ResolvedEnv {
+  const allowedOrigins = (env.APP_ORIGINS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+
+  const googleClientIds = (env.GOOGLE_CLIENT_IDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const googleJwksUrl = env.GOOGLE_JWKS_URL ?? 'https://www.googleapis.com/oauth2/v3/certs';
+
+  const sessionHmacSecret = env.SESSION_HMAC_SECRET ?? '';
+  if (!sessionHmacSecret) throw new Error('Missing env.SESSION_HMAC_SECRET');
+  if (googleClientIds.length === 0) throw new Error('Missing env.GOOGLE_CLIENT_IDS');
+  if (allowedOrigins.length === 0) throw new Error('Missing env.APP_ORIGINS');
+
+  const accessTtlSeconds = Number(env.ACCESS_TTL_SECONDS ?? 60 * 60 * 24 * 14); // 14 days
+  const refreshTtlSeconds = Number(env.REFRESH_TTL_SECONDS ?? 60 * 60 * 24 * 365); // 365 days
+
+  return {
+    allowedOrigins,
+    googleClientIds,
+    googleJwksUrl,
+    sessionHmacSecret,
+    accessTtlSeconds,
+    refreshTtlSeconds,
+  };
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,11 +1,53 @@
+import type { Env } from './env';
+import { sessionHandlers } from './auth/session';
+import { notFound, json } from './lib/http';
+import { enforceOrigin, enforceRateLimit } from './security/middleware';
+import { getClientIp } from './security/clientKey';
+
+const LOGIN_RATE_LIMIT = {
+  capacity: 10,
+  refillPerSecond: 0.2, // 1 token per 5s
+  retryAfterSeconds: 10,
+} as const;
+
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
     if (url.pathname === '/health') {
-      return Response.json({ ok: true });
+      return json(200, { ok: true });
     }
 
-    return new Response('Not Found', { status: 404 });
+    if (url.pathname.startsWith('/api/')) {
+      try {
+        const originCheck = enforceOrigin(request, env);
+        if (!originCheck.ok) return originCheck.response;
+
+        const ip = getClientIp(request);
+        const rateKey = `ip:${ip}:path:${url.pathname}`;
+        const rl = enforceRateLimit(rateKey, request, LOGIN_RATE_LIMIT);
+        if (!rl.ok) return rl.response;
+
+        if (url.pathname === '/api/session') {
+          if (request.method === 'POST') return sessionHandlers.login(request, env);
+          if (request.method === 'DELETE') return sessionHandlers.logout(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+
+        if (url.pathname === '/api/session/refresh') {
+          if (request.method === 'POST') return sessionHandlers.refresh(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+
+        if (url.pathname === '/api/me') {
+          if (request.method === 'GET') return sessionHandlers.me(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+      } catch (err) {
+        return json(500, { error: 'server_error' });
+      }
+    }
+
+    return notFound();
   },
 };

--- a/apps/worker/src/lib/base64url.ts
+++ b/apps/worker/src/lib/base64url.ts
@@ -1,0 +1,21 @@
+export function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+  const b64 = btoa(binary);
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+export function base64UrlDecodeToBytes(input: string): Uint8Array {
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export function base64UrlDecodeToString(input: string): string {
+  const bytes = base64UrlDecodeToBytes(input);
+  return new TextDecoder().decode(bytes);
+}

--- a/apps/worker/src/lib/cookies.ts
+++ b/apps/worker/src/lib/cookies.ts
@@ -1,0 +1,32 @@
+export type CookieOptions = {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'Lax' | 'Strict' | 'None';
+  path?: string;
+  maxAge?: number;
+};
+
+export function parseCookieHeader(headerValue: string | null): Record<string, string> {
+  if (!headerValue) return {};
+  const out: Record<string, string> = {};
+  for (const part of headerValue.split(';')) {
+    const [rawName, ...rawValueParts] = part.trim().split('=');
+    if (!rawName) continue;
+    const value = rawValueParts.join('=');
+    out[rawName] = value;
+  }
+  return out;
+}
+
+export function serializeCookie(name: string, value: string, options: CookieOptions = {}): string {
+  const segments: string[] = [`${name}=${value}`];
+  const path = options.path ?? '/';
+  segments.push(`Path=${path}`);
+
+  if (options.maxAge !== undefined) segments.push(`Max-Age=${options.maxAge}`);
+  if (options.httpOnly !== false) segments.push('HttpOnly');
+  if (options.secure) segments.push('Secure');
+  if (options.sameSite) segments.push(`SameSite=${options.sameSite}`);
+
+  return segments.join('; ');
+}

--- a/apps/worker/src/lib/http.ts
+++ b/apps/worker/src/lib/http.ts
@@ -1,0 +1,41 @@
+export type JsonObject = Record<string, unknown>;
+
+export function json(status: number, body: JsonObject, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set('Content-Type', 'application/json; charset=utf-8');
+  return new Response(JSON.stringify(body), { ...init, status, headers });
+}
+
+export function noContent(init: ResponseInit = {}): Response {
+  return new Response(null, { ...init, status: init.status ?? 204 });
+}
+
+export function methodNotAllowed(): Response {
+  return json(405, { error: 'method_not_allowed' });
+}
+
+export function notFound(): Response {
+  return json(404, { error: 'not_found' });
+}
+
+export function unauthorized(): Response {
+  return json(401, { error: 'unauthorized' });
+}
+
+export function forbidden(reason?: string): Response {
+  return json(403, { error: 'forbidden', reason });
+}
+
+export function tooManyRequests(retryAfterSeconds: number): Response {
+  return json(
+    429,
+    { error: 'rate_limited', retryAfterSeconds },
+    { headers: { 'Retry-After': String(retryAfterSeconds) } },
+  );
+}
+
+export async function readJson<T>(request: Request): Promise<T> {
+  const text = await request.text();
+  if (!text) throw new Error('empty_json');
+  return JSON.parse(text) as T;
+}

--- a/apps/worker/src/lib/rateLimit.ts
+++ b/apps/worker/src/lib/rateLimit.ts
@@ -1,0 +1,38 @@
+type Bucket = {
+  tokens: number;
+  updatedAtMs: number;
+};
+
+export type RateLimitConfig = {
+  capacity: number;
+  refillPerSecond: number;
+  retryAfterSeconds: number;
+};
+
+const buckets = new Map<string, Bucket>();
+
+export function takeToken(key: string, nowMs: number, config: RateLimitConfig): boolean {
+  const existing = buckets.get(key);
+  if (!existing) {
+    buckets.set(key, { tokens: config.capacity - 1, updatedAtMs: nowMs });
+    return true;
+  }
+
+  const elapsedSeconds = Math.max(0, (nowMs - existing.updatedAtMs) / 1000);
+  const refill = elapsedSeconds * config.refillPerSecond;
+  const nextTokens = Math.min(config.capacity, existing.tokens + refill);
+
+  if (nextTokens < 1) {
+    existing.tokens = nextTokens;
+    existing.updatedAtMs = nowMs;
+    return false;
+  }
+
+  existing.tokens = nextTokens - 1;
+  existing.updatedAtMs = nowMs;
+  return true;
+}
+
+export function clearRateLimitStateForTests(): void {
+  buckets.clear();
+}

--- a/apps/worker/src/security/clientKey.ts
+++ b/apps/worker/src/security/clientKey.ts
@@ -1,0 +1,7 @@
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get('CF-Connecting-IP') ||
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ||
+    '0.0.0.0'
+  );
+}

--- a/apps/worker/src/security/csrf.ts
+++ b/apps/worker/src/security/csrf.ts
@@ -1,0 +1,9 @@
+import { parseCookieHeader } from '../lib/cookies';
+
+export function verifyGoogleCsrfToken(request: Request, bodyToken: string | undefined): boolean {
+  if (!bodyToken) return false;
+  const cookies = parseCookieHeader(request.headers.get('Cookie'));
+  const cookieToken = cookies['g_csrf_token'];
+  if (!cookieToken) return false;
+  return cookieToken === bodyToken;
+}

--- a/apps/worker/src/security/middleware.ts
+++ b/apps/worker/src/security/middleware.ts
@@ -1,0 +1,29 @@
+import { resolveEnv, type Env } from '../env';
+import { forbidden, tooManyRequests } from '../lib/http';
+import { takeToken, type RateLimitConfig } from '../lib/rateLimit';
+import { isAllowedOrigin, isStateChangingMethod } from './origin';
+
+export type SecurityResult = { ok: true } | { ok: false; response: Response };
+
+export function enforceOrigin(request: Request, env: Env): SecurityResult {
+  if (!isStateChangingMethod(request.method)) return { ok: true };
+
+  const { allowedOrigins } = resolveEnv(env);
+  const origin = request.headers.get('Origin');
+  if (!isAllowedOrigin(origin, allowedOrigins)) return { ok: false, response: forbidden('bad_origin') };
+
+  return { ok: true };
+}
+
+export function enforceRateLimit(
+  key: string,
+  request: Request,
+  config: RateLimitConfig,
+): SecurityResult {
+  if (!isStateChangingMethod(request.method)) return { ok: true };
+
+  const ok = takeToken(key, Date.now(), config);
+  if (!ok) return { ok: false, response: tooManyRequests(config.retryAfterSeconds) };
+
+  return { ok: true };
+}

--- a/apps/worker/src/security/origin.ts
+++ b/apps/worker/src/security/origin.ts
@@ -1,0 +1,8 @@
+export function isStateChangingMethod(method: string): boolean {
+  return method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS';
+}
+
+export function isAllowedOrigin(origin: string | null, allowed: string[]): boolean {
+  if (!origin) return false;
+  return allowed.includes(origin);
+}

--- a/apps/worker/wrangler.toml
+++ b/apps/worker/wrangler.toml
@@ -3,7 +3,15 @@ main = "src/index.ts"
 compatibility_date = "2025-07-18"
 
 [vars]
-# Placeholder vars; fill in later as needed.
+# Local dev defaults.
+# In production, set secrets via: `wrangler secret put SESSION_HMAC_SECRET`.
+APP_ORIGINS = "http://localhost:5173"
+
+# Comma-separated Google OAuth client ids (audience).
+GOOGLE_CLIENT_IDS = "CHANGE_ME"
+
+# Used to sign access cookies. Replace for any shared environment.
+SESSION_HMAC_SECRET = "dev-secret-change-me"
 
 [[r2_buckets]]
 binding = "R2"


### PR DESCRIPTION
Implements the Phase 1 LEAN issue P1-1 (cookie sessions + CSRF/Origin + basic rate limiting).

Summary:
- Adds session endpoints: `POST /api/session`, `POST /api/session/refresh`, `DELETE /api/session`, `GET /api/me`
- Access cookie is HMAC-signed (no KV read on normal auth), refresh token is opaque and stored/rotated in KV
- Enforces Origin checks for all state-changing endpoints; login also validates `g_csrf_token` (double-submit)
- Adds lightweight in-memory token bucket rate limiting for state-changing endpoints

Testing:
- `pnpm -C apps/worker test`
- Local smoke: `/health` returns 200; `/api/me` returns 401; POST without Origin returns 403