### PR TITLE
P1-2: Index API pack (GET index + commit + soft delete + purge)

### DIFF
--- a/apps/worker/src/auth/requireUser.ts
+++ b/apps/worker/src/auth/requireUser.ts
@@ -1,0 +1,19 @@
+import type { Env } from '../env';
+import { resolveEnv } from '../env';
+import { parseCookieHeader } from '../lib/cookies';
+import { unauthorized } from '../lib/http';
+import { ACCESS_COOKIE } from './cookies';
+import { verifyAccessToken } from './access';
+
+export type RequireUserResult = { ok: true; userId: string } | { ok: false; response: Response };
+
+export async function requireUser(request: Request, env: Env): Promise<RequireUserResult> {
+  const resolved = resolveEnv(env);
+  const cookies = parseCookieHeader(request.headers.get('Cookie'));
+  const token = cookies[ACCESS_COOKIE];
+
+  const verified = await verifyAccessToken(token, resolved.sessionHmacSecret);
+  if (!verified.ok) return { ok: false, response: unauthorized() };
+
+  return { ok: true, userId: verified.userId };
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3,6 +3,12 @@ import { sessionHandlers } from './auth/session';
 import { notFound, json } from './lib/http';
 import { enforceOrigin, enforceRateLimit } from './security/middleware';
 import { getClientIp } from './security/clientKey';
+import {
+  handleCommitRecord,
+  handleGetIndex,
+  handlePurge,
+  handleSoftDelete,
+} from './index/indexHandlers';
 
 const LOGIN_RATE_LIMIT = {
   capacity: 10,
@@ -41,6 +47,26 @@ export default {
 
         if (url.pathname === '/api/me') {
           if (request.method === 'GET') return sessionHandlers.me(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+
+        if (url.pathname === '/api/index') {
+          if (request.method === 'GET') return handleGetIndex(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+
+        if (url.pathname === '/api/records/commit') {
+          if (request.method === 'POST') return handleCommitRecord(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+
+        if (url.pathname === '/api/records/soft-delete') {
+          if (request.method === 'POST') return handleSoftDelete(request, env);
+          return json(405, { error: 'method_not_allowed' });
+        }
+
+        if (url.pathname === '/api/records/purge') {
+          if (request.method === 'POST') return handlePurge(request, env);
           return json(405, { error: 'method_not_allowed' });
         }
       } catch (err) {

--- a/apps/worker/src/index/indexHandlers.test.ts
+++ b/apps/worker/src/index/indexHandlers.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import worker from '../index';
+import { mintAccessToken } from '../auth/access';
+
+class MemoryKV {
+  async get(): Promise<string | null> {
+    return null;
+  }
+  async put(): Promise<void> {
+    // no-op
+  }
+  async delete(): Promise<void> {
+    // no-op
+  }
+}
+
+type StoredObject = { body: string; etag: string; contentType?: string };
+
+class MemoryR2 {
+  private store = new Map<string, StoredObject>();
+  private etagCounter = 0;
+  public deletes: string[] = [];
+
+  async get(key: string): Promise<any | null> {
+    const obj = this.store.get(key);
+    if (!obj) return null;
+    return {
+      etag: obj.etag,
+      async text() {
+        return obj.body;
+      },
+    };
+  }
+
+  async head(key: string): Promise<any | null> {
+    const obj = this.store.get(key);
+    if (!obj) return null;
+    return { etag: obj.etag };
+  }
+
+  async put(key: string, value: string, options?: any): Promise<{ etag: string }> {
+    const onlyIf = options?.onlyIf;
+    const match = onlyIf?.etagMatches;
+
+    const existing = this.store.get(key);
+    if (match !== undefined) {
+      if (!existing || existing.etag !== match) {
+        throw new Error('precondition_failed');
+      }
+    }
+
+    this.etagCounter++;
+    const etag = `\"mem-${this.etagCounter}\"`;
+    this.store.set(key, {
+      body: value,
+      etag,
+      contentType: options?.httpMetadata?.contentType,
+    });
+
+    return { etag };
+  }
+
+  async delete(key: string): Promise<void> {
+    this.deletes.push(key);
+    this.store.delete(key);
+  }
+}
+
+async function authedEnvAndCookie(userId: string) {
+  const r2 = new MemoryR2();
+  const secret = 'test-secret';
+  const access = await mintAccessToken(userId, secret, 3600);
+  const cookie = `__Host-ve_access=${access}`;
+
+  const env = {
+    KV: new MemoryKV() as unknown as KVNamespace,
+    R2: r2 as unknown as R2Bucket,
+    APP_ORIGINS: 'http://localhost:5173',
+    GOOGLE_CLIENT_IDS: 'client-1',
+    SESSION_HMAC_SECRET: secret,
+  };
+
+  return { env, cookie, r2 };
+}
+
+describe('index API (P1-2)', () => {
+  it('GET /api/index returns 200 + ETag and supports 304', async () => {
+    const { env, cookie } = await authedEnvAndCookie('u_1');
+
+    const first = await worker.fetch(
+      new Request('http://worker.test/api/index', {
+        method: 'GET',
+        headers: { Cookie: cookie },
+      }),
+      env as never,
+    );
+
+    expect(first.status).toBe(200);
+    const etag1 = first.headers.get('ETag');
+    expect(etag1).toBeTruthy();
+    const body1 = (await first.json()) as any;
+    expect(body1.schema).toBe('voice-echo.index.v1');
+    expect(Array.isArray(body1.records)).toBe(true);
+
+    const second = await worker.fetch(
+      new Request('http://worker.test/api/index', {
+        method: 'GET',
+        headers: { Cookie: cookie, 'If-None-Match': etag1! },
+      }),
+      env as never,
+    );
+
+    expect(second.status).toBe(304);
+  });
+
+  it('commit -> soft-delete -> purge updates index with optimistic concurrency', async () => {
+    const { env, cookie, r2 } = await authedEnvAndCookie('u_2');
+
+    const indexRes = await worker.fetch(
+      new Request('http://worker.test/api/index', { method: 'GET', headers: { Cookie: cookie } }),
+      env as never,
+    );
+    const etag1 = indexRes.headers.get('ETag')!;
+
+    const recordId = '01TESTREC';
+    const audioKey = `users/u_2/records/${recordId}/audio.webm`;
+
+    const commitRes = await worker.fetch(
+      new Request('http://worker.test/api/records/commit', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          Cookie: cookie,
+          'Content-Type': 'application/json',
+          'If-Match': etag1,
+        },
+        body: JSON.stringify({
+          recordId,
+          durationMs: 1234,
+          mimeType: 'audio/webm',
+          audioKey,
+          bytes: 42,
+          title: 'Hello',
+        }),
+      }),
+      env as never,
+    );
+
+    expect(commitRes.status).toBe(200);
+    const etag2 = commitRes.headers.get('ETag')!;
+    expect(etag2).not.toEqual(etag1);
+
+    const staleCommit = await worker.fetch(
+      new Request('http://worker.test/api/records/commit', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          Cookie: cookie,
+          'Content-Type': 'application/json',
+          'If-Match': etag1,
+        },
+        body: JSON.stringify({ recordId, durationMs: 1234, mimeType: 'audio/webm', audioKey }),
+      }),
+      env as never,
+    );
+    expect(staleCommit.status).toBe(409);
+
+    const softDeleteRes = await worker.fetch(
+      new Request('http://worker.test/api/records/soft-delete', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          Cookie: cookie,
+          'Content-Type': 'application/json',
+          'If-Match': etag2,
+        },
+        body: JSON.stringify({ recordId }),
+      }),
+      env as never,
+    );
+
+    expect(softDeleteRes.status).toBe(200);
+    const etag3 = softDeleteRes.headers.get('ETag')!;
+
+    const purgeRes = await worker.fetch(
+      new Request('http://worker.test/api/records/purge', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          Cookie: cookie,
+          'Content-Type': 'application/json',
+          'If-Match': etag3,
+        },
+        body: JSON.stringify({ recordId }),
+      }),
+      env as never,
+    );
+
+    expect(purgeRes.status).toBe(200);
+    expect(r2.deletes).toContain(audioKey);
+
+    const indexAfter = await worker.fetch(
+      new Request('http://worker.test/api/index', { method: 'GET', headers: { Cookie: cookie } }),
+      env as never,
+    );
+    const bodyAfter = (await indexAfter.json()) as any;
+    expect(bodyAfter.records.find((r: any) => r.id === recordId)).toBeUndefined();
+  });
+
+  it('commit rejects durationMs > 12h', async () => {
+    const { env, cookie } = await authedEnvAndCookie('u_3');
+
+    const indexRes = await worker.fetch(
+      new Request('http://worker.test/api/index', { method: 'GET', headers: { Cookie: cookie } }),
+      env as never,
+    );
+    const etag = indexRes.headers.get('ETag')!;
+
+    const recordId = '01LONG';
+    const res = await worker.fetch(
+      new Request('http://worker.test/api/records/commit', {
+        method: 'POST',
+        headers: {
+          Origin: 'http://localhost:5173',
+          Cookie: cookie,
+          'Content-Type': 'application/json',
+          'If-Match': etag,
+        },
+        body: JSON.stringify({
+          recordId,
+          durationMs: 43_200_000 + 1,
+          mimeType: 'audio/webm',
+          audioKey: `users/u_3/records/${recordId}/audio.webm`,
+        }),
+      }),
+      env as never,
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/worker/src/index/indexHandlers.ts
+++ b/apps/worker/src/index/indexHandlers.ts
@@ -1,0 +1,208 @@
+import type { Env } from '../env';
+import { json, noContent } from '../lib/http';
+import { requireUser } from '../auth/requireUser';
+import { loadOrCreateIndex, makeNewRecord, saveIndexWithEtag, sortRecordsNewestFirst, touchIndex } from './indexStore';
+import { MAX_DURATION_MS } from './indexTypes';
+
+function isUnderUserPrefix(userId: string, key: string): boolean {
+  const prefix = `users/${userId}/`;
+  return key.startsWith(prefix);
+}
+
+function recordAudioPrefix(userId: string, recordId: string): string {
+  return `users/${userId}/records/${recordId}/`;
+}
+
+export async function handleGetIndex(request: Request, env: Env): Promise<Response> {
+  const user = await requireUser(request, env);
+  if (!user.ok) return user.response;
+
+  const loaded = await loadOrCreateIndex(env, user.userId);
+
+  const inm = request.headers.get('If-None-Match');
+  if (inm && inm === loaded.etag) {
+    return noContent({
+      status: 304,
+      headers: {
+        ETag: loaded.etag,
+        'Cache-Control': 'private, max-age=0, must-revalidate',
+      },
+    });
+  }
+
+  return json(200, loaded.index as unknown as Record<string, unknown>, {
+    headers: {
+      ETag: loaded.etag,
+      'Cache-Control': 'private, max-age=0, must-revalidate',
+    },
+  });
+}
+
+export async function handleCommitRecord(request: Request, env: Env): Promise<Response> {
+  const user = await requireUser(request, env);
+  if (!user.ok) return user.response;
+
+  const ifMatch = request.headers.get('If-Match');
+  if (!ifMatch) return json(400, { error: 'missing_if_match' });
+
+  const body = (await request.json().catch(() => null)) as null | {
+    recordId?: string;
+    title?: string;
+    description?: string;
+    tags?: string[];
+    durationMs?: number;
+    mimeType?: string;
+    audioKey?: string;
+    bytes?: number;
+    createdAt?: string;
+  };
+
+  if (!body?.recordId || !body.durationMs || !body.mimeType || !body.audioKey) {
+    return json(400, { error: 'bad_request' });
+  }
+
+  if (body.durationMs > MAX_DURATION_MS) return json(400, { error: 'duration_too_long' });
+
+  if (!isUnderUserPrefix(user.userId, body.audioKey)) return json(400, { error: 'bad_audio_key' });
+  if (!body.audioKey.startsWith(recordAudioPrefix(user.userId, body.recordId))) {
+    return json(400, { error: 'bad_audio_key' });
+  }
+
+  const loaded = await loadOrCreateIndex(env, user.userId);
+  if (loaded.etag !== ifMatch) {
+    return json(409, { error: 'etag_mismatch', indexEtag: loaded.etag }, { headers: { ETag: loaded.etag } });
+  }
+
+  const now = new Date().toISOString();
+  const existing = loaded.index.records.find((r) => r.id === body.recordId);
+  const nextRecord =
+    existing
+      ? {
+          ...existing,
+          updatedAt: now,
+          title: body.title ?? existing.title,
+          description: body.description ?? existing.description,
+          tags: body.tags ?? existing.tags,
+          durationMs: body.durationMs,
+          audio: {
+            ...existing.audio,
+            key: body.audioKey,
+            mime: body.mimeType,
+            bytes: body.bytes ?? existing.audio.bytes,
+          },
+        }
+      : makeNewRecord({
+          recordId: body.recordId,
+          createdAt: body.createdAt,
+          title: body.title,
+          description: body.description,
+          tags: body.tags,
+          durationMs: body.durationMs,
+          audioKey: body.audioKey,
+          mimeType: body.mimeType,
+          bytes: body.bytes,
+        });
+
+  const nextIndex = touchIndex({
+    ...loaded.index,
+    records: sortRecordsNewestFirst([
+      nextRecord,
+      ...loaded.index.records.filter((r) => r.id !== body.recordId),
+    ]),
+  });
+
+  try {
+    const nextEtag = await saveIndexWithEtag(env, loaded, ifMatch, nextIndex);
+    return json(200, { record: nextRecord, indexEtag: nextEtag }, { headers: { ETag: nextEtag } });
+  } catch {
+    const latest = await loadOrCreateIndex(env, user.userId);
+    return json(409, { error: 'etag_mismatch', indexEtag: latest.etag }, { headers: { ETag: latest.etag } });
+  }
+}
+
+export async function handleSoftDelete(request: Request, env: Env): Promise<Response> {
+  const user = await requireUser(request, env);
+  if (!user.ok) return user.response;
+
+  const ifMatch = request.headers.get('If-Match');
+  if (!ifMatch) return json(400, { error: 'missing_if_match' });
+
+  const body = (await request.json().catch(() => null)) as null | { recordId?: string };
+  if (!body?.recordId) return json(400, { error: 'bad_request' });
+
+  const loaded = await loadOrCreateIndex(env, user.userId);
+  if (loaded.etag !== ifMatch) {
+    return json(409, { error: 'etag_mismatch', indexEtag: loaded.etag }, { headers: { ETag: loaded.etag } });
+  }
+
+  const record = loaded.index.records.find((r) => r.id === body.recordId);
+  if (!record) return json(404, { error: 'not_found' });
+
+  const now = new Date().toISOString();
+  const nextRecord = {
+    ...record,
+    status: 'deleted' as const,
+    deletedAt: record.deletedAt ?? now,
+    updatedAt: now,
+  };
+
+  const nextIndex = touchIndex({
+    ...loaded.index,
+    records: sortRecordsNewestFirst([
+      nextRecord,
+      ...loaded.index.records.filter((r) => r.id !== body.recordId),
+    ]),
+  });
+
+  try {
+    const nextEtag = await saveIndexWithEtag(env, loaded, ifMatch, nextIndex);
+    return json(200, { record: nextRecord, indexEtag: nextEtag }, { headers: { ETag: nextEtag } });
+  } catch {
+    const latest = await loadOrCreateIndex(env, user.userId);
+    return json(409, { error: 'etag_mismatch', indexEtag: latest.etag }, { headers: { ETag: latest.etag } });
+  }
+}
+
+export async function handlePurge(request: Request, env: Env): Promise<Response> {
+  const user = await requireUser(request, env);
+  if (!user.ok) return user.response;
+
+  const ifMatch = request.headers.get('If-Match');
+  if (!ifMatch) return json(400, { error: 'missing_if_match' });
+
+  const body = (await request.json().catch(() => null)) as null | { recordId?: string };
+  if (!body?.recordId) return json(400, { error: 'bad_request' });
+
+  const loaded = await loadOrCreateIndex(env, user.userId);
+  if (loaded.etag !== ifMatch) {
+    return json(409, { error: 'etag_mismatch', indexEtag: loaded.etag }, { headers: { ETag: loaded.etag } });
+  }
+
+  const record = loaded.index.records.find((r) => r.id === body.recordId);
+  if (!record) {
+    return json(200, { indexEtag: loaded.etag }, { headers: { ETag: loaded.etag } });
+  }
+
+  if (record.status !== 'deleted') return json(400, { error: 'record_not_deleted' });
+
+  if (!isUnderUserPrefix(user.userId, record.audio.key)) return json(400, { error: 'bad_audio_key' });
+
+  try {
+    await env.R2.delete(record.audio.key);
+  } catch {
+    // idempotent: missing object is fine
+  }
+
+  const nextIndex = touchIndex({
+    ...loaded.index,
+    records: loaded.index.records.filter((r) => r.id !== body.recordId),
+  });
+
+  try {
+    const nextEtag = await saveIndexWithEtag(env, loaded, ifMatch, nextIndex);
+    return json(200, { indexEtag: nextEtag }, { headers: { ETag: nextEtag } });
+  } catch {
+    const latest = await loadOrCreateIndex(env, user.userId);
+    return json(409, { error: 'etag_mismatch', indexEtag: latest.etag }, { headers: { ETag: latest.etag } });
+  }
+}

--- a/apps/worker/src/index/indexStore.ts
+++ b/apps/worker/src/index/indexStore.ts
@@ -1,0 +1,114 @@
+import type { Env } from '../env';
+import type { IndexV1, RecordSummaryV1 } from './indexTypes';
+
+function indexKeyForUser(userId: string): string {
+  return `users/${userId}/index.json`;
+}
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+function utcDay(iso: string): string {
+  return iso.slice(0, 10);
+}
+
+export function createEmptyIndex(): IndexV1 {
+  return {
+    schema: 'voice-echo.index.v1',
+    rev: 1,
+    updatedAt: isoNow(),
+    records: [],
+  };
+}
+
+export function sortRecordsNewestFirst(records: RecordSummaryV1[]): RecordSummaryV1[] {
+  return records
+    .slice()
+    .sort((a, b) => (a.createdAt < b.createdAt ? 1 : a.createdAt > b.createdAt ? -1 : a.id < b.id ? 1 : -1));
+}
+
+export type LoadedIndex = {
+  key: string;
+  etag: string;
+  index: IndexV1;
+};
+
+export async function loadOrCreateIndex(env: Env, userId: string): Promise<LoadedIndex> {
+  const key = indexKeyForUser(userId);
+
+  const existing = await env.R2.get(key);
+  if (!existing) {
+    const empty = createEmptyIndex();
+    const put = await env.R2.put(key, JSON.stringify(empty), {
+      httpMetadata: { contentType: 'application/json; charset=utf-8' },
+    });
+
+    const etag = put?.etag;
+    return { key, etag: etag ?? '"missing_etag"', index: empty };
+  }
+
+  const text = await existing.text();
+  const parsed = JSON.parse(text) as IndexV1;
+  return { key, etag: existing.etag, index: parsed };
+}
+
+export async function saveIndexWithEtag(
+  env: Env,
+  loaded: LoadedIndex,
+  expectedEtag: string,
+  nextIndex: IndexV1,
+): Promise<string> {
+  const body = JSON.stringify(nextIndex);
+  const put = await env.R2.put(loaded.key, body, {
+    httpMetadata: { contentType: 'application/json; charset=utf-8' },
+    onlyIf: { etagMatches: expectedEtag },
+  });
+
+  if (!put?.etag) {
+    const head = await env.R2.head(loaded.key);
+    return head?.etag ?? '"missing_etag"';
+  }
+
+  return put.etag;
+}
+
+export function touchIndex(index: IndexV1): IndexV1 {
+  return {
+    ...index,
+    rev: (index.rev ?? 0) + 1,
+    updatedAt: isoNow(),
+  };
+}
+
+export function makeNewRecord(args: {
+  recordId: string;
+  createdAt?: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+  durationMs: number;
+  audioKey: string;
+  mimeType: string;
+  bytes?: number;
+}): RecordSummaryV1 {
+  const createdAt = args.createdAt ?? isoNow();
+  return {
+    id: args.recordId,
+    parentId: null,
+    createdAt,
+    updatedAt: isoNow(),
+    createdDay: utcDay(createdAt),
+    title: args.title ?? '',
+    description: args.description,
+    tags: args.tags,
+    durationMs: args.durationMs,
+    status: 'active',
+    deletedAt: null,
+    audio: {
+      key: args.audioKey,
+      mime: args.mimeType,
+      bytes: args.bytes,
+    },
+  };
+}

--- a/apps/worker/src/index/indexTypes.ts
+++ b/apps/worker/src/index/indexTypes.ts
@@ -1,0 +1,32 @@
+export type IndexV1 = {
+  schema: 'voice-echo.index.v1';
+  rev: number;
+  updatedAt: string;
+  records: RecordSummaryV1[];
+};
+
+export type RecordStatus = 'active' | 'deleted';
+
+export type AudioPointerV1 = {
+  key: string;
+  mime: string;
+  bytes?: number;
+  etag?: string;
+};
+
+export type RecordSummaryV1 = {
+  id: string;
+  parentId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  createdDay: string;
+  title: string;
+  description?: string;
+  tags?: string[];
+  durationMs: number;
+  status: RecordStatus;
+  deletedAt: string | null;
+  audio: AudioPointerV1;
+};
+
+export const MAX_DURATION_MS = 43_200_000;


### PR DESCRIPTION
Implements LEAN issue P1-2 (Index API pack) on top of merged P1-1.

Endpoints:
- `GET /api/index` (ETag + `If-None-Match` -> `304`)
- `POST /api/records/commit` (ETag optimistic concurrency via `If-Match`)
- `POST /api/records/soft-delete` (mark deleted in index)
- `POST /api/records/purge` (delete R2 audio + remove record; only when deleted)

Notes:
- Index is stored at `users/{userId}/index.json` and is created if missing.
- Mutations use R2 conditional put (`onlyIf.etagMatches`) to enforce CAS.
- Enforces 12h max duration on commit.

Testing:
- `pnpm -C apps/worker test`
- Manual smoke: authed `GET /api/index` returns 200 + ETag and 304 on revalidate